### PR TITLE
fix(api): use DELETE method for user delete endpoint

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -23,7 +23,7 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
             Route::post('logout', [AuthController::class, 'logout']);
             Route::get('me', [UserController::class, 'profile']);
             Route::put('update', [UserController::class, 'update']);
-            Route::post('delete', [UserController::class, 'delete']);
+            Route::delete('delete', [UserController::class, 'delete']);
         });
 
     Route::prefix('social-auth')->group(function () {


### PR DESCRIPTION
Change the user delete route from POST to DELETE in the API routes. This corrects the HTTP verb to better reflect a resource deletion operation, improves REST semantics, and allows clients and intermediaries to handle the request appropriately (e.g., routing, caching, and security rules).