### PR TITLE
fix(auth): remove commented-out Arabic token line in SocialAuthContro…

### DIFF
--- a/app/Http/Controllers/SocialAuthController.php
+++ b/app/Http/Controllers/SocialAuthController.php
@@ -44,7 +44,6 @@ class SocialAuthController extends Controller
 
 //     $data = $response->json();
 
-//     // ده الـ Access Token
 //     $accessToken = $data['access_token'];
 
 //     return response()->json([


### PR DESCRIPTION
…ller

Remove an inline commented Arabic description of the access token from the SocialAuthController to clean up dead code and improve readability. The change deletes a stray commented line that duplicated information already present in surrounding comments, reducing clutter and potential confusion for future maintainers.