### PR TITLE
feat(social-auth): expose client routes and restrict FB scopes

### DIFF
--- a/app/Http/Controllers/SocialAuthController.php
+++ b/app/Http/Controllers/SocialAuthController.php
@@ -31,7 +31,7 @@ class SocialAuthController extends Controller
         ]);
     }
 
-//     public function callback(Request $request, string $provider)
+//  public function callback(Request $request, string $provider)
 // {
 //     $code = $request->get('code');
 

--- a/app/Services/SocialNetworks/FacebookService.php
+++ b/app/Services/SocialNetworks/FacebookService.php
@@ -19,7 +19,7 @@ class FacebookService implements SocialNetworkInterface
 
     public function getAuthUrl(): string
     {
-        $scopes = "pages_manage_posts,pages_show_list,pages_read_engagement,public_profile";
+        $scopes = "public_profile";
 
         return "https://www.facebook.com/v17.0/dialog/oauth?"
             . http_build_query([

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,6 +17,10 @@ Route::prefix('auth')->group(function () {
     Route::post('verifyOtp', [AuthController::class, 'verifyOtp']);
 });
 
+    Route::prefix('client')->group(function () {
+        Route::get('{network}/redirect', [SocialAuthController::class, 'redirect']);
+        Route::get('callback/{network}', [SocialAuthController::class, 'callback']);
+    });
 
 Route::group(['middleware' => ['auth:sanctum']], function () {
         Route::prefix('profile')->group(function () {
@@ -26,10 +30,7 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
             Route::delete('delete', [UserController::class, 'delete']);
         });
 
-    Route::prefix('social-auth')->group(function () {
-        Route::get('{network}/redirect', [SocialAuthController::class, 'redirect']);
-        Route::get('{network}/callback', [SocialAuthController::class, 'callback']);
-    });
+
     Route::resource('social-networks', SocialNetworkController::class);
     Route::resource('social-accounts', SocialAccountController::class);
 });


### PR DESCRIPTION
Update route structure to add public client endpoints for social authentication and adjust authenticated-area routes. Add a new Route::('client') group in api.php with GET endpoints for {network}/redirect and callback/{network} to allow front-end clients to initiate and complete social login flows without requiring sanctum authentication. Remove the duplicate social-auth prefix group from the authenticated section to avoid redundant or conflicting routes. Keep authenticated resources (social-networks, social-accounts) unchanged.

Also normalize a commented method signature in SocialAuthController for formatting consistency.

Reduce Facebook OAuth scopes in FacebookService from a broad set to only "public_profile" to limit requested permissions and simplify the consent experience.