### PR TITLE
feat(auth): add IsAdmin middleware and restrict admin routes

### DIFF
--- a/app/Http/Middleware/IsAdmin.php
+++ b/app/Http/Middleware/IsAdmin.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class IsAdmin
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+         $admin = auth()->user();
+   
+        if (! $admin || $admin->type !== "admin" || $admin->is_active != 1) {
+            return response()->json([
+                'message' => 'ليس لديك صلاحية لدخول لوحة التحكم',
+            ], 409);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -20,6 +20,7 @@ class UserResource extends JsonResource
             'email' => $this->email,
             'status' => $this->status,
             'is_active' => $this->is_active,
+            'type' => $this->type,
             'organisations' => OrganisationResource::collection($this->whenLoaded('organisations')),
         ];
     }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\IsAdmin;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -12,7 +13,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'IsAdmin' => IsAdmin::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,15 +13,19 @@ use App\Http\Controllers\SocialNetworkController;
 
 Route::prefix('auth')->group(function () {
     Route::post('login', [AuthController::class, 'login']);
-    Route::post('register', [AuthController::class, 'register']);
+    // Route::post('register', [AuthController::class, 'register']);
     Route::post('sendOpt', [AuthController::class, 'sendOpt']);
     Route::post('verifyOtp', [AuthController::class, 'verifyOtp']);
 });
 
-    Route::prefix('client')->group(function () {
-        Route::get('{network}/redirect', [SocialAuthController::class, 'redirect']);
-        Route::get('callback/{network}', [SocialAuthController::class, 'callback']);
-    });
+
+Route::group(['middleware' => ['auth:sanctum','IsAdmin']], function () {
+    Route::post('organisations/{organisation}/add-user', [OrganisationController::class, 'addUser']);
+    Route::delete('organisations/{organisation}/remove-user/{user}', [OrganisationController::class, 'removeUser']);
+    Route::apiResource('organisations', OrganisationController::class);
+    Route::apiResource('social-networks', SocialNetworkController::class);
+
+  });  
 
 Route::group(['middleware' => ['auth:sanctum']], function () {
     Route::prefix('profile')->group(function () {
@@ -31,14 +35,15 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
         Route::delete('delete', [UserController::class, 'delete']);
     });
 
-    Route::post('organisations/{organisation}/add-user', [OrganisationController::class, 'addUser']);
-    Route::delete('organisations/{organisation}/remove-user/{user}', [OrganisationController::class, 'removeUser']);
+
+    Route::prefix('client')->group(function () {
+        Route::get('{network}/redirect', [SocialAuthController::class, 'redirect']);
+        Route::get('callback/{network}', [SocialAuthController::class, 'callback']);
+    });
 
 
-
-    Route::apiResource('social-networks', SocialNetworkController::class);
     Route::apiResource('social-accounts', SocialAccountController::class);
-    Route::apiResource('organisations', OrganisationController::class);
+
 });
 
 


### PR DESCRIPTION
Add IsAdmin middleware that checks authenticated user's type is "admin" and that the user is active. Return a localized error message and 409 on unauthorized access. Register the middleware alias in bootstrap/app.php so it can be referenced by name.

Protect organisation and social-network management routes by grouping them behind auth:sanctum and IsAdmin middleware in routes/api.php. Move client social auth routes into the auth:sanctum group and re-enable organisation resource routes for admin-only access. Comment out public registration route.

Expose user's type in API responses by adding 'type' to UserResource.php so clients can identify admin users.