### PR TITLE
feat(auth): email verification token and set-password flow

### DIFF
--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -93,7 +93,26 @@ class AuthController extends Controller
             ], 200);
 
     }
+  public function setPassword(Request $request, $token): JsonResponse
+    {
+        $request->validate([
+            'password' => 'required|string|min:6|confirmed',
+        ]);
 
+        $user = User::where('verification_token', $token)->first();
+
+        if (!$user) {
+            return response()->json(['message' => 'Invalid token'], 422);
+        }
+
+        $user->update([
+            'password' => Hash::make($request->password),
+            'verification_token' => null,
+            'status' => 1,
+        ]);
+
+        return response()->json(['message' => 'Password has been set successfully'], 200);
+    }
     public function login(Request $request)
     {
         $request->validate([
@@ -118,4 +137,6 @@ class AuthController extends Controller
             'token' => $token
         ]);
     }
+    
+  
 }

--- a/app/Http/Controllers/OrganizationController.php
+++ b/app/Http/Controllers/OrganizationController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Mail\WelcomeMail;
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use App\Http\Resources\UserResource;
 use Illuminate\Support\Facades\Mail;
@@ -78,8 +79,8 @@ class OrganizationController extends Controller
             $user = $this->UserRepository->create([
                 'name'     => $data['name'],
                 'email'    => $data['email'],
-                'password' => bcrypt($data['password']),
-                'status'    => 1,
+                'verification_token' => Str::random(60),
+                'status'    => 0,
                 'is_active'    => 1,
             ]);
             if(!$user){

--- a/app/Http/Requests/Organization/AddUserRequest.php
+++ b/app/Http/Requests/Organization/AddUserRequest.php
@@ -25,7 +25,6 @@ class AddUserRequest extends FormRequest
             'user_id'   => 'nullable|exists:users,id',
             'name'      => 'nullable|required_without:user_id|string|max:255',
             'email'     => 'nullable|required_without:user_id|email|unique:users,email',
-            'password'  => 'nullable|required_without:user_id|string|min:6',
         ];
     }
 
@@ -39,9 +38,6 @@ class AddUserRequest extends FormRequest
             'email.required_without'    => 'البريد الإلكتروني مطلوب عند عدم اختيار مستخدم.',
             'email.email'               => 'يجب إدخال بريد إلكتروني صالح.',
             'email.unique'              => 'هذا البريد الإلكتروني مستخدم بالفعل.',
-            'password.required_without' => 'كلمة المرور مطلوبة عند عدم اختيار مستخدم.',
-            'password.string'           => 'كلمة المرور يجب أن تكون نصًا.',
-            'password.min'              => 'كلمة المرور يجب أن تكون على الأقل 6 أحرف.',
         ];
     }
     

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -20,7 +20,7 @@ class UserResource extends JsonResource
             'email' => $this->email,
             'status' => $this->status,
             'is_active' => $this->is_active,
-            'type' => $this->type,
+            'type'     => $this->type,
             'organizations' => OrganizationResource::collection($this->whenLoaded('organizations')),
         ];
     }

--- a/app/Mail/WelcomeMail.php
+++ b/app/Mail/WelcomeMail.php
@@ -36,10 +36,12 @@ class WelcomeMail extends Mailable
 
     public function content(): Content
     {
+         $link = url("/set-password/{$this->user->verification_token}");
         return new Content(
             view: 'emails.welcome',
             with: [
                 'user' => $this->user,
+                'link' => $link
             ]
         );
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -25,6 +25,7 @@ class User extends Authenticatable  implements HasMedia
         'status',
         'otp',
         'otp_expires_at',
+        'verification_token',
         
     ];
  

--- a/database/migrations/2025_08_23_170501_add_status_and_verification_token_to_users_table.php
+++ b/database/migrations/2025_08_23_170501_add_status_and_verification_token_to_users_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+          $table->string('password')->nullable()->change();
+          $table->string('verification_token', 100)->nullable()->after('status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/resources/views/emails/welcome.blade.php
+++ b/resources/views/emails/welcome.blade.php
@@ -70,7 +70,9 @@
                 يمكنك الآن تسجيل الدخول والبدء في استكشاف المميزات الرائعة التي نوفرها لك.
             </p>
             <p style="text-align: center;">
-                <a href="{{ url('/') }}" class="btn">ابدأ الآن</a>
+                <a href="{{ url('/set-password/' . $user->verification_token) }}" class="btn">
+                    إنشاء كلمة المرور وتفعيل الحساب
+                </a>
             </p>
         </div>
         <div class="footer">

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,6 +16,7 @@ Route::prefix('auth')->group(function () {
     // Route::post('register', [AuthController::class, 'register']);
     Route::post('sendOpt', [AuthController::class, 'sendOpt']);
     Route::post('verifyOtp', [AuthController::class, 'verifyOtp']);
+    Route::post('set-password/{token}', [AuthController::class, 'setPassword']);
 });
 
 


### PR DESCRIPTION
Introduce verification_token on users and adjust registration to create a token instead of setting an immediate active password. Make passwords nullable in the users table to allow account creation without a password. Change new user status to inactive (0) and generate a 60-char token for email verification.

Add set-password endpoint to verify token, set the password, clear the token, and activate the account (status = 1). Update Welcome email and mail content to include a link to the set-password route. Remove direct password requirement from AddUserRequest validation and related error messages to support the invite/verify flow.

Expose verification_token in the User model and tidy up UserResource formatting. Add migration to add verification_token and change password column nullability.