### PR TITLE
feat(user): allow nullable fields and improve profile update flow

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -25,14 +25,23 @@ private UserRepositoryInterface $UserRepository;
 
     public function update(UserRequest $request)
     {
-    $data = $request->validated();
-    if ($request->hasFile('photo')) {
-        $userPath = $request->file('photo')->store('user', 'public');
-        $data['photo'] = $userPath;
-    }
+        $data = $request->validated();
+        if ($request->hasFile('photo')) {
+            $userPath = $request->file('photo')->store('user', 'public');
+            $data['photo'] = $userPath;
+        }
+        $data = array_filter($data, fn($value) => !empty($value));
 
-    $user = $this->UserRepository->update($request->user()->id, $data);
-    return UserResource::make($user);
+        if (isset($data['password'])) {
+            $data['password'] = bcrypt($data['password']);
+        }
+
+        $user = $this->UserRepository->update($request->user()->id, $data);
+        return response()->json([
+            'message' => 'تم تحديث الحساب بنجاح',
+            'data'    => UserResource::make($user)
+        ]);
+     
     }
 
     public function delete(Request $request)

--- a/app/Http/Requests/User/UserRequest.php
+++ b/app/Http/Requests/User/UserRequest.php
@@ -22,9 +22,9 @@ class UserRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => 'sometimes|string|max:255',
-            'email' => 'sometimes|string|email|max:255|unique:users,email,' . $this->user()->id,
-            'password' => 'sometimes|string|max:255',
+            'name' => 'sometimes|nullable|string|max:255',
+            'email' => 'sometimes|nullable|string|email|max:255|unique:users,email,' . $this->user()->id,
+            'password' => 'sometimes|nullable|string|max:255',
             'photo' => 'sometimes|nullable|image|mimes:jpeg,png,jpg,gif,svg|max:2048',
         ];
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -32,7 +32,7 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
     Route::prefix('profile')->group(function () {
         Route::post('logout', [AuthController::class, 'logout']);
         Route::get('me', [UserController::class, 'profile']);
-        Route::put('update', [UserController::class, 'update']);
+        Route::PATCH('update', [UserController::class, 'update']);
         Route::delete('delete', [UserController::class, 'delete']);
     });
 


### PR DESCRIPTION
Make name, email and password nullable in UserRequest so empty values are accepted when fields are optional. Trim submitted update payload by filtering out empty values before persistence to avoid overwriting existing data with empty strings.

Hash password when present and return a localized JSON success message with the updated user resource from update(). Change profile update route to use PATCH to better match partial updates semantics.

In AuthController::sendOpt add robust error handling:
- return 422 when email is not found
- wrap sending logic in try/catch and return 500 on failure with error details
- return 200 on success with a clear message

These changes improve API reliability, security (password hashing), and align HTTP semantics for partial updates.