### PR TITLE
feat(organization): add StoreRequest and use it in controller

### DIFF
--- a/app/Http/Requests/Organization/StoreRequest.php
+++ b/app/Http/Requests/Organization/StoreRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests\Organization;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'description' => 'nullable|string',
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'name.required' => 'اسم المنظمة مطلوب.',
+            'name.string' => 'اسم المنظمة يجب أن يكون نصًا.',
+            'name.max' => 'اسم المنظمة لا يجب أن يزيد عن 255 حرفًا.',
+            'description.string' => 'الوصف يجب أن يكون نصًا.',
+        ];
+    }
+}


### PR DESCRIPTION
Introduce a FormRequest (StoreRequest) for organization creation to centralize validation and error messages. Replace
validation in OrganizationController::store with the request's validated data, and preserve file upload handling. Wrap store logic in a try/catch to return a JSON error response on exception.

This cleans up the controller, moves validation rules/messages into a dedicated request class, and improves error handling for create ops.