### PR TITLE
fix(org): return 409 on organization create conflict

### DIFF
--- a/app/Http/Controllers/OrganizationController.php
+++ b/app/Http/Controllers/OrganizationController.php
@@ -50,8 +50,8 @@ class OrganizationController extends Controller
             return response()->json([
                 'message' => 'Failed to create organization',
                 'error' => $e->getMessage()
-            ], 500);
-    }
+            ], 409);
+        }
     }
     public function show($slug)
     {


### PR DESCRIPTION
Change the HTTP response code from 500 to 409 when organization creation fails due to a conflict, and properly close the exception handler block. This prevents misleading server-error responses and accurately signals a client-side conflict (e.g., duplicate resource), improving API semantics and error handling.