### PR TITLE
refactor(s): rename route and harden social APIs

### DIFF
--- a/app/Http/Controllers/SocialAuthController.php
+++ b/app/Http/Controllers/SocialAuthController.php
@@ -17,15 +17,19 @@ class SocialAuthController extends Controller
 
      protected function resolveService(string $provider)
     {
-        if (!isset($this->services[$provider])) {
-            abort(409, "Provider not supported");
-        }
-        return $this->services[$provider];
+        return $this->services[$provider] ?? null;
     }
 
     public function redirect(string $provider)
     {
         $service = $this->resolveService($provider);
+        if (!$service) {
+            return response()->json([
+                'message' => 'Provider not supported'
+            ], 400);
+        }
+
+
         return response()->json([
             'url' => $service->getAuthUrl()
         ]);

--- a/app/Http/Controllers/SocialNetworkController.php
+++ b/app/Http/Controllers/SocialNetworkController.php
@@ -47,6 +47,7 @@ class SocialNetworkController extends Controller
             $iconPath  = $request->file('icon')->store('social', 'public');
             $data['icon'] = $iconPath ;
         }
+        $data = array_filter($data, fn($value) => $value !== null);
         $socialNetwork = $this->SocialNetworkRepository->update($slug, $data);
         if (!$socialNetwork) {
             return response()->json(['message' => 'Social Network not found'], 409);

--- a/app/Http/Requests/SocialNetwork/SocialNetworkRequest.php
+++ b/app/Http/Requests/SocialNetwork/SocialNetworkRequest.php
@@ -22,8 +22,8 @@ class SocialNetworkRequest extends FormRequest
     public function rules(): array
     {
             return [
-            'name'      => 'sometimes|string|max:255',
-            'url'       => 'sometimes|url|max:255',
+            'name'      => 'sometimes|nullable|string|max:255',
+            'url'       => 'sometimes|nullable|url|max:255',
             'is_active' => 'sometimes|in:0,1',
             'icon'      => 'sometimes|nullable|string|max:255',
         ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -37,7 +37,7 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
     });
 
 
-    Route::prefix('client')->group(function () {
+    Route::prefix('social-auth')->group(function () {
         Route::get('{network}/redirect', [SocialAuthController::class, 'redirect']);
         Route::get('callback/{network}', [SocialAuthController::class, 'callback']);
     });


### PR DESCRIPTION
Rename client route to social for clearer intent and update the SocialAuth flow for safer provider handling Validate the resolved provider and return a 400 JSON response when unsupported instead of aborting. This avoids uncaught HTTP exceptions and provides a consistent API error format.

Improve SocialNetworkController update logic by filtering out null values from the update payload so existing fields are not overwritten with null unintentionally.

Tighten request validation rules for social network updates by allowing explicit nulls for optional fields (name, url, icon) while preserving other constraints. This enables clients to send nullable values safely.