### PR TITLE
chore(env): add Instagram OAuth vars to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,3 +70,7 @@ VITE_APP_NAME="${APP_NAME}"
 FB_APP_ID=
 FB_APP_SECRET=
 FB_REDIRECT_URI=
+
+instagram_APP_ID=
+instagram_APP_SECRET=
+instagram_REDIRECT_URI=


### PR DESCRIPTION
Add placeholder environment variables for Instagram OAuth: instagram_APP_ID, instagram_APP_SECRET, and
instagram_REDIRECT_URI.

These match existing Facebook vars to document required keys for integrating Instagram authentication and make it easier for contributors to configure OAuth locally.