### PR TITLE
feat(posts): add posts system, controller, migration, and interfaces

### DIFF
--- a/app/Http/Controllers/OrganizationController.php
+++ b/app/Http/Controllers/OrganizationController.php
@@ -144,7 +144,7 @@ class OrganizationController extends Controller
             if ($request->hasFile('logo')) {
                 $userPath = $request->file('logo')->store('Organization', 'public');
                 $data['logo'] = $userPath;
-            }
+     }
             $data = array_filter($data, fn($value) => !empty($value));
             $this->OrganizationRepository->update($Organization->id, $data);
 

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Http\Resources\PostResource;
+use App\Repositories\Interfaces\PostRepositoryInterface;
+use App\Repositories\Interfaces\SocialAccountRepositoryInterface;
+
+class PostController extends Controller
+{
+private PostRepositoryInterface $PostRepository;
+private SocialAccountRepositoryInterface $SocialAccountRepository;
+    
+    public function __construct(
+        SocialAccountRepositoryInterface $SocialAccountRepository,
+        PostRepositoryInterface $PostRepository
+        )
+    {
+        $this->PostRepository = $PostRepository;
+        $this->SocialAccountRepository = $SocialAccountRepository;
+    }
+
+    public function index(Request $request, $account, $status)
+    {
+        $SocialAccount = $this->SocialAccountRepository->getByAccountId($account);
+        if (!$SocialAccount) {
+            return response()->json([
+                'message' => 'Social Account not found'
+            ], 400);
+        }
+        $posts = $this->PostRepository->getAllByAccount($SocialAccount->id, $status, auth()->id());
+        return PostResource::collection($posts);
+        //return response()->json($posts);
+    }
+
+    public function store(Request $request, $account)
+    {
+           $SocialAccount = $this->SocialAccountRepository->getByAccountId($account);
+        if (!$SocialAccount) {
+            return response()->json([
+                'message' => 'Social Account not found'
+            ], 400);
+        }
+
+        $data = $request->validate([
+            'type'         => 'required|in:post,reel,story',
+            'content'      => 'required|string',
+            'published_at' => 'required|date',
+            'photos'       => 'nullable|array', 
+            'photos.*'     => 'file|mimes:jpg,jpeg,png,mp4,mov,avi|max:10240', 
+        ]);
+        $data['user_id'] = auth()->id();
+        $data['social_account_id'] = $SocialAccount->id;
+        $post = $this->PostRepository->create($data);
+
+        return response()->json($post, 201);
+    }
+}

--- a/app/Http/Controllers/TimeSlotController.php
+++ b/app/Http/Controllers/TimeSlotController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\TimeSlot;
+use Illuminate\Http\Request;
+use App\Http\Resources\TimeSlotResource;
+
+class TimeSlotController extends Controller
+{
+    public function index()
+    {
+        return TimeSlotResource::collection(TimeSlot::all());
+    }
+}

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -18,7 +18,7 @@ private UserRepositoryInterface $UserRepository;
 
     public function profile(Request $request)
     {
-        $user = $this->UserRepository->getById($request->user()->id);
+        $user = $this->UserRepository->getById(auth()->id());
         return UserResource::make($user);
 
     }
@@ -36,7 +36,7 @@ private UserRepositoryInterface $UserRepository;
             $data['password'] = bcrypt($data['password']);
         }
 
-        $user = $this->UserRepository->update($request->user()->id, $data);
+        $user = $this->UserRepository->update(auth()->id(), $data);
         return response()->json([
             'message' => 'تم تحديث الحساب بنجاح',
             'data'    => UserResource::make($user)
@@ -46,7 +46,7 @@ private UserRepositoryInterface $UserRepository;
 
     public function delete(Request $request)
     {
-        $this->UserRepository->delete($request->user()->id);
+        $this->UserRepository->delete(auth()->id());
         return response()->json(['message' => 'User deleted successfully'], 200);
     }
 

--- a/app/Http/Resources/PostResource.php
+++ b/app/Http/Resources/PostResource.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PostResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'user_id'  => $this->user_id,
+            'social_account_id' => $this->social_account_id,
+            'type' => $this->type,
+            'content' => $this->content,
+            'external_post_id' => $this->external_post_id,
+            'status' => $this->status,
+            'published_at' => $this->published_at,
+        ];
+    }
+}

--- a/app/Http/Resources/TimeSlotResource.php
+++ b/app/Http/Resources/TimeSlotResource.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class TimeSlotResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+         return [
+            'label'  => $this->label,
+            'time' => $this->time,
+         ];
+    }
+}

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Laravel\Sanctum\HasApiTokens;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class Post extends Model
+{
+   use HasApiTokens, HasFactory, SoftDeletes;
+
+    protected $fillable = [
+        'user_id',
+        'social_account_id',
+        'type',
+        'content',
+        'external_post_id',
+        'status',
+        'published_at',
+    ];
+
+
+}

--- a/app/Models/TimeSlot.php
+++ b/app/Models/TimeSlot.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Laravel\Sanctum\HasApiTokens;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class TimeSlot extends Model
+{
+     use HasApiTokens, HasFactory, SoftDeletes;
+
+        protected $fillable = [
+        'label',
+        'time',
+    ];
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,12 +2,14 @@
 
 namespace App\Providers;
 
+use App\Repositories\PostRepository;
 use App\Repositories\UserRepository;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 use App\Repositories\OrganizationRepository;
 use App\Repositories\SocialAccountRepository;
 use App\Repositories\SocialNetworkRepository;
+use App\Repositories\Interfaces\PostRepositoryInterface;
 use App\Repositories\Interfaces\UserRepositoryInterface;
 use App\Repositories\Interfaces\OrganizationRepositoryInterface;
 use App\Repositories\Interfaces\SocialAccountRepositoryInterface;
@@ -20,6 +22,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
+
+        $this->app->bind(PostRepositoryInterface::class, PostRepository::class);
         $this->app->bind(SocialAccountRepositoryInterface::class, SocialAccountRepository::class);
         $this->app->bind(SocialNetworkRepositoryInterface::class, SocialNetworkRepository::class);
         $this->app->bind(OrganizationRepositoryInterface::class, OrganizationRepository::class);

--- a/app/Repositories/Interfaces/PostRepositoryInterface.php
+++ b/app/Repositories/Interfaces/PostRepositoryInterface.php
@@ -2,11 +2,11 @@
 
 namespace App\Repositories\Interfaces;
 
-interface SocialAccountRepositoryInterface
+interface PostRepositoryInterface
 {
     public function getAll();
-    public function getBySlug($slug);
-    public function getByAccountId($id);
+    public function getById($id);
+    public function getAllByAccount($account,$status,$UserId);
     public function create(array $attributes);
     public function update($id, array $attributes);
     public function delete($id);

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Repositories\Interfaces\PostRepositoryInterface;
+use App\Models\Post; // Assumption: You have a Model with the same name
+
+class PostRepository implements PostRepositoryInterface
+{
+    public function getAllByAccount($account,$status,$UserId)
+    {
+        return Post::query()
+            ->where('social_account_id', $account)
+            ->where('user_id', $UserId)
+            ->where('status', $status)
+            ->orderBy('created_at', 'desc')
+            ->get();
+    }
+
+    public function getAll()
+    {
+        return Post::all();
+    }
+
+    public function getById($id)
+    {
+        return Post::find($id);
+    }
+
+    public function create(array $attributes)
+    {
+        return Post::create($attributes);
+    }
+
+    public function update($id, array $attributes)
+    {
+        $record = Post::find($id);
+        if ($record) {
+            $record->update($attributes);
+            return $record;
+        }
+        return null;
+    }
+
+    public function delete($id)
+    {
+        $record = Post::find($id);
+        if ($record) {
+            return $record->delete();
+        }
+        return false;
+    }
+}

--- a/app/Repositories/SocialAccountRepository.php
+++ b/app/Repositories/SocialAccountRepository.php
@@ -12,6 +12,14 @@ class SocialAccountRepository implements SocialAccountRepositoryInterface
         return SocialAccount::all();
     }
 
+    public function getByAccountId($id)
+    {
+        return SocialAccount::query()
+            ->whereHas('socialNetwork', function ($query) use ($id) {
+                $query->where('account_id', $id);
+            })
+            ->first();
+    }
     public function getBySlug($slug)
     {
         return SocialAccount::query()

--- a/database/migrations/2025_08_24_091440_create_time_slots_table.php
+++ b/database/migrations/2025_08_24_091440_create_time_slots_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('time_slots', function (Blueprint $table) {
+            $table->id();
+            $table->string('label');
+            $table->time('time');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('time_slots');
+    }
+};

--- a/database/migrations/2025_08_24_094043_create_posts_table.php
+++ b/database/migrations/2025_08_24_094043_create_posts_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->foreignId('social_account_id') ->constrained() ->onDelete('cascade');
+            $table->enum('type', ['post', 'reel', 'story'])->default('post');
+            $table->text('content')->nullable();
+            $table->string('external_post_id')->nullable();
+            $table->enum('status', ['queue', 'drafts', 'approvals','sent', 'failed'])->default('queue');
+            $table->timestamp('published_at');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('posts');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -16,6 +16,7 @@ class DatabaseSeeder extends Seeder
         $this->call([
             UserSeeder::class,
             SocialNetworkSeeder::class,
+            TimeSlotSeeder::class,
         ]);
     }
 }

--- a/database/seeders/TimeSlotSeeder.php
+++ b/database/seeders/TimeSlotSeeder.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\TimeSlot;
+use Illuminate\Database\Seeder;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+
+class TimeSlotSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $slots = [
+            ['label' => '08:30 PM', 'time' => '08:30:00'],
+            ['label' => '17:00 PM',  'time' => '17:00:00'],
+        ];
+
+        foreach ($slots as $slot) {
+            TimeSlot::updateOrCreate(['time' => $slot['time']], $slot);
+        }
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,9 +3,11 @@
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\UserController;
+use App\Http\Controllers\TimeSlotController;
 use App\Http\Controllers\Auth\AuthController;
-use App\Http\Controllers\OrganizationController;
 use App\Http\Controllers\SocialAuthController;
+use App\Http\Controllers\OrganizationController;
+use App\Http\Controllers\PostController;
 use App\Http\Controllers\SocialAccountController;
 use App\Http\Controllers\SocialNetworkController;
 
@@ -42,7 +44,11 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
         Route::get('callback/{network}', [SocialAuthController::class, 'callback']);
     });
 
-
+    Route::get('time-slots', [TimeSlotController::class, 'index']);
+    Route::prefix('posts')->group(function () {
+        Route::post('channels/{account}/store', [PostController::class, 'store']);
+        Route::get('channels/{account}/{type}', [PostController::class, 'index']);
+    });
     Route::apiResource('social-accounts', SocialAccountController::class);
 
 });


### PR DESCRIPTION
Introduce foundational post functionality and related changes to enable creating and listing posts tied to social accounts.

Key changes:
- Add PostRepositoryInterface defining CRUD methods and a method to fetch posts by account and status.
- Add PostController with index and store actions. Validate request payloads, check social account existence, and delegate persistence to repositories. Return PostResource collections and created responses.
- Add migration to create posts table with relations to users and social accounts, enums for type and status, published_at timestamp, and soft deletes.
- Register TimeSlotSeeder in DatabaseSeeder and add a TimeSlot model (fillable: label, time).
- Begin wiring repository imports in AppServiceProvider (add Post repository import and interface reference).

Why:
- Provide a persistent posts data model and controller endpoints to support scheduling and managing posts per social account.
- Define repository interface to decouple controller logic from storage implementation and enable easier testing and future implementations.