### PR TITLE
feat(facebook): switch FB requests to form POST and improve posting

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use Carbon\Carbon;
 use Illuminate\Http\Request;
 use App\Http\Resources\PostResource;
 use App\Repositories\Interfaces\PostRepositoryInterface;
@@ -31,7 +32,6 @@ private SocialAccountRepositoryInterface $SocialAccountRepository;
         }
         $posts = $this->PostRepository->getAllByAccount($SocialAccount->id, $status, auth()->id());
         return PostResource::collection($posts);
-        //return response()->json($posts);
     }
 
     public function store(Request $request, $account)

--- a/app/Jobs/ClearExpiredOtpsJob.php
+++ b/app/Jobs/ClearExpiredOtpsJob.php
@@ -16,9 +16,9 @@ class ClearExpiredOtpsJob implements ShouldQueue
 
     public function handle(): void
     {
-
+        $now = Carbon::now()->format('Y-m-d H:i:s');
         User::whereNotNull('otp')
-            ->where('otp_expires_at', '<', now())
+            ->where('otp_expires_at', '<', $now)
             ->update([
                 'otp' => null,
                 'otp_expires_at' => null,

--- a/app/Jobs/PublishScheduledPostsJob.php
+++ b/app/Jobs/PublishScheduledPostsJob.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Jobs;
+
+use Carbon\Carbon;
+use App\Models\Post;
+use App\Services\SocialPublisher;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class PublishScheduledPostsJob implements ShouldQueue
+{
+    use Queueable;
+
+    public function handle(): void
+    {
+       $now = Carbon::now()->format('Y-m-d H:i:s');
+        $posts = Post::where('status', 'queue')
+            ->where('published_at', '<=', $now)
+            ->get();
+
+        foreach ($posts as $post) {
+            try {
+       
+                app(SocialPublisher::class)->publish($post);
+   
+                $post->update([
+                    'status' => 'sent',
+                    'published_at' => $now,
+                ]);
+            } catch (\Exception $e) {
+                $post->update([
+                    'status' => 'failed',
+                ]);
+            }
+        }
+    }
+}

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -21,5 +21,12 @@ class Post extends Model
         'published_at',
     ];
 
+    protected function casts(): array
+    {
+        return [
+            'published_at' => 'datetime',
+        ];
+    }
+
 
 }

--- a/app/Services/SocialNetworks/InstagramService.php
+++ b/app/Services/SocialNetworks/InstagramService.php
@@ -31,7 +31,7 @@ class InstagramService implements SocialNetworkInterface
 
     public function getAccessToken(string $code): string
     {
-        $shortResponse = Http::get('https://graph.facebook.com/v17.0/oauth/access_token', [
+        $shortResponse = Http::asForm()->post('https://graph.facebook.com/v17.0/oauth/access_token', [
             'client_id'     => $this->clientId,
             'client_secret' => $this->clientSecret,
             'redirect_uri'  => $this->redirectUri,
@@ -44,7 +44,7 @@ class InstagramService implements SocialNetworkInterface
             throw new \Exception('Failed to get short-lived access token: ' . json_encode($shortResponse->json()));
         }
 
-        $longResponse = Http::get('https://graph.facebook.com/v17.0/oauth/access_token', [
+        $longResponse = Http::asForm()->post('https://graph.facebook.com/v17.0/oauth/access_token', [
             'grant_type'        => 'fb_exchange_token',
             'client_id'         => $this->clientId,
             'client_secret'     => $this->clientSecret,
@@ -60,21 +60,9 @@ class InstagramService implements SocialNetworkInterface
         return $longLivedToken;
     }
 
-    // public function getAccessToken(string $code): string
-    // {
-    //     $response = Http::get('https://graph.facebook.com/v17.0/oauth/access_token', [
-    //         'client_id'     => $this->clientId,
-    //         'client_secret' => $this->clientSecret,
-    //         'redirect_uri'  => $this->redirectUri,
-    //         'code'          => $code,
-    //     ]);
-
-    //     return $response->json()['access_token'] ?? '';
-    // }
-
     public function getUserProfile(string $accessToken): array
     {
-        $response = Http::get("https://graph.facebook.com/me", [
+        $response = Http::asForm()->post("https://graph.facebook.com/me", [
             'fields'        => 'id,name,picture',
             'access_token'  => $accessToken,
         ]);

--- a/app/Services/SocialPublisher.php
+++ b/app/Services/SocialPublisher.php
@@ -1,0 +1,33 @@
+<?php
+namespace App\Services;
+
+use App\Models\Post;
+use Illuminate\Support\Facades\Http;
+
+class SocialPublisher
+{
+
+    protected $services;
+
+    public function __construct(array $services)
+    {
+        $this->services = $services;
+    }
+
+    public function publish(Post $post)
+    {
+        $account = $post->socialAccount;
+        $network = $account->social_network->name; 
+
+        $service = $this->services[$network] ?? null;
+
+        if (!$service) {
+            throw new \Exception("شبكة غير مدعومة: $network");
+        }
+
+        return $service->publishPost($account->access_token, $post);
+    }
+
+    
+  
+}


### PR DESCRIPTION
Change FacebookService to use application/x-www-form-urlencoded POST requests (Http::asForm()->post) for token exchange and profile calls to match Facebook's OAuth endpoints and avoid query size/encoding issues. Simplify and extend publishPost to support posting to a specific target ID, include an optional link field, strip null values from the payload, and throw a clear exception on failure. Remove older commented variants kept previously.

fix(jobs): normalize OTP time comparison in ClearExpiredOtpsJob

Evaluate expiration against a formatted Carbon timestamp ($now) instead of calling now() inside the query to ensure consistent value usage and avoid any DB/Query builder differences.

refactor(posts): add casts for published_at and clean controller

Add a published_at cast on Post model to return a DateTime. Remove a stray commented return in PostController and add an unused Carbon import (prepared for future usage).

feat(service): add SocialPublisher service

Introduce SocialPublisher to centralize publishing logic across networks. It looks up a service by network name and delegates publishPost, raising a clear error for unsupported networks. This prepares for multi-network publishing flows.