### PR TITLE
feat(posts): link posts to users and use Carbon objects

### DIFF
--- a/app/Jobs/PublishScheduledPostsJob.php
+++ b/app/Jobs/PublishScheduledPostsJob.php
@@ -14,10 +14,12 @@ class PublishScheduledPostsJob implements ShouldQueue
 
     public function handle(): void
     {
-       $now = Carbon::now()->format('Y-m-d H:i:s');
+       $now = Carbon::now();
+
         $posts = Post::where('status', 'queue')
             ->where('published_at', '<=', $now)
             ->get();
+
 
         foreach ($posts as $post) {
             try {

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Carbon\Carbon;
 use Laravel\Sanctum\HasApiTokens;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -28,5 +29,9 @@ class Post extends Model
         ];
     }
 
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -56,4 +56,9 @@ class User extends Authenticatable  implements HasMedia
     {
         return $this->belongsToMany(organization::class);
     }
+
+    public function posts()
+    {
+        return $this->hasMany(Post::class);
+    }
 }


### PR DESCRIPTION
Add explicit user-post relationships and use Carbon instances for time comparisons in the scheduler.

- Add Carbon import to Post model and define user() belongsTo relation so posts are associated with their author.
- Add posts() hasMany relation to User model to enable inverse relation and easier eager loading/queries.
- Change PublishScheduledPostsJob to use Carbon::now() as a DateTime object (instead of formatted string) so published_at comparisons work reliably with date/time columns and query builders.

These changes improve data integrity and make scheduled post publication comparisons more robust.