### PR TITLE
feat(scheduling): register publish & clear OTP scheduled jobs

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -1,10 +1,12 @@
 <?php
 
 
+use App\Jobs\ClearExpiredOtpsJob;
 use Illuminate\Foundation\Inspiring;
+use App\Jobs\PublishScheduledPostsJob;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Schedule;
-use App\Jobs\ClearExpiredOtpsJob;
+
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
@@ -12,3 +14,4 @@ Artisan::command('inspire', function () {
 
 
 Schedule::job(new ClearExpiredOtpsJob)->hourly();
+Schedule::job(new PublishScheduledPostsJob)->everyMinute();


### PR DESCRIPTION
Add PublishScheduledPostsJob to the console scheduler and reorder imports for clarity. Keep ClearExpiredOtpsJob scheduled hourly and add PublishScheduledPostsJob to run every minute so scheduled posts are published promptly. This centralizes recurrent tasks in routes/console.php and ensures timely post publication and periodic OTP cleanup.