### PR TITLE
fix(user): password and photo updates

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -32,12 +32,13 @@ private UserRepositoryInterface $UserRepository;
      
         $data = array_filter($data, fn($value) => !empty($value));
 
-        if (isset($data['password'])) {
+        if (!empty($data['password'])) {
             $data['password'] = bcrypt($data['password']);
         }
 
         $user = $this->UserRepository->update(auth()->id(), $data);
         if ($photo) {
+            $user->clearMediaCollection('user');
             $user->addMedia($photo)
                 ->toMediaCollection('user'); 
         }


### PR DESCRIPTION
Use explicit emptiness checks when processing password input to
 hashing empty strings. Only hash and persist the password if
it contains a non-empty value.

Clear the user's existing media before adding a new photo so that the user media collection does not accumulate old files when a new image is uploaded. These changes prevent accidental overwrites stale media retention.