### PR TITLE
feat(admin): add admin controller, request, and repo

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Arr;
+use Illuminate\Http\Request;
+use App\Http\Resources\AdminResource;
+use App\Http\Requests\Admin\AdminRequest;
+use App\Repositories\Interfaces\UserRepositoryInterface;
+
+class AdminController extends Controller
+{
+private UserRepositoryInterface $UserRepository;
+    
+    public function __construct(UserRepositoryInterface $UserRepository)
+    {
+        $this->UserRepository = $UserRepository;
+    }
+
+    public function index(Request $request)
+    {
+        $users = $this->UserRepository->getAllByType("admin");
+         return AdminResource::collection($users);
+    }
+
+    public function store(AdminRequest $request)
+    {
+        $data = $request->validated();
+  
+        $data['password'] = bcrypt($data['password']);
+         $photo = Arr::pull($data, 'photo');
+         
+        $user = $this->UserRepository->create($data);
+
+        try {
+            if ($photo) {
+                $user->addMedia($photo)->toMediaCollection('user');
+            }
+        } catch (\Exception $e) {
+            return response()->json([
+                'message' => 'فشل رفع الصورة',
+                'error'   => $e->getMessage(),
+            ], 500);
+        }
+
+        return response()->json(
+            [
+                'message' => 'Admin created successfully', 
+                'data' => AdminResource::make($user)
+            ], 201);
+    }
+
+    public function show($id)
+    {
+        $user = $this->UserRepository->getById($id);
+        return response()->json(['data' => $user]);
+    }
+    public function update(Request $request, $id)
+    {
+        $data = $request->validate([
+            'name' => 'sometimes|required|string|max:255',
+            'email' => 'sometimes|required|string|email|max:255|unique:users,email,' . $id,
+            'password' => 'sometimes|required|string|min:8',
+            'type' => 'sometimes|required|string|in:admin,user',
+        ]);
+
+        if (isset($data['password'])) {
+            $data['password'] = bcrypt($data['password']);
+        }
+
+        $user = $this->UserRepository->update($id, $data);
+        return response()->json(['message' => 'Admin updated successfully', 'data' => $user]);
+    }
+
+    public function destroy($id)
+    {
+        $this->UserRepository->delete($id);
+        return response()->json(['message' => 'Admin deleted successfully'], 200);
+    }
+
+
+}

--- a/app/Http/Requests/Admin/AdminRequest.php
+++ b/app/Http/Requests/Admin/AdminRequest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AdminRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'email'    => 'required|string|email|max:255|unique:users,email,' . ($this->user()->id ?? 'NULL'),
+            'password' => 'required|string|min:6',
+            'photo' => 'nullable|image|mimes:jpeg,png,jpg,gif,svg,webp|max:2048',
+
+        ];
+    }
+
+        public function messages(): array
+    {
+        return [
+            'name.required'   => 'الاسم مطلوب.',
+            'name.string'     => 'الاسم يجب أن يكون نصًا صحيحًا.',
+            'name.max'        => 'الاسم يجب ألا يزيد عن 255 حرفًا.',
+
+            'email.required'  => 'البريد الإلكتروني مطلوب.',
+            'email.email'     => 'يجب إدخال بريد إلكتروني صالح.',
+            'email.unique'    => 'هذا البريد الإلكتروني مستخدم بالفعل.',
+            'email.max'       => 'البريد الإلكتروني يجب ألا يزيد عن 255 حرفًا.',
+
+            'password.required' => 'كلمة المرور مطلوبة.',
+            'password.min'      => 'كلمة المرور يجب ألا تقل عن 6 أحرف.',
+
+            'photo.image'  => 'الملف يجب أن يكون صورة.',
+            'photo.mimes'  => 'الصورة يجب أن تكون بصيغة: jpeg, png, jpg, gif, svg, webp.',
+            'photo.max'    => 'حجم الصورة يجب ألا يتجاوز 2 ميجابايت.',
+        ];
+    }
+}

--- a/app/Http/Resources/AdminResource.php
+++ b/app/Http/Resources/AdminResource.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class AdminResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+         return [
+            'id'    => $this->id,
+            'name'  => $this->name,
+            'email' => $this->email,
+            'status' => $this->status,
+            'is_active' => $this->is_active,
+            'type'     => $this->type,
+            'photo' => $this->getFirstMediaUrl('user') ?: asset('default/default-user.png'),
+         ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -47,10 +47,6 @@ class User extends Authenticatable  implements HasMedia
     {
         return $this->hasMany(SocialAccount::class);
     }
-    public function getPhotoUrlAttribute()
-    {
-        return $this->getFirstMediaUrl('photo') ?: asset('images/default-avatar.png');
-    }
 
     public function organizations()
     {

--- a/app/Repositories/Interfaces/UserRepositoryInterface.php
+++ b/app/Repositories/Interfaces/UserRepositoryInterface.php
@@ -4,7 +4,7 @@ namespace App\Repositories\Interfaces;
 
 interface UserRepositoryInterface
 {
-    public function getAll();
+    public function getAllByType($type);
     public function getById($id);
     public function create(array $attributes);
     public function update($id, array $attributes);

--- a/app/Repositories/UserRepository.php
+++ b/app/Repositories/UserRepository.php
@@ -7,9 +7,12 @@ use App\Models\User; // Assumption: You have a Model with the same name
 
 class UserRepository implements UserRepositoryInterface
 {
-    public function getAll()
+    public function getAllByType($type)
     {
-        return User::all();
+        return User::query()
+         ->where('type',$type)->paginate(10);
+
+        return User::getAllByType($type);
     }
 
     public function getById($id)

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,12 +2,13 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\PostController;
 use App\Http\Controllers\UserController;
+use App\Http\Controllers\AdminController;
 use App\Http\Controllers\TimeSlotController;
 use App\Http\Controllers\Auth\AuthController;
 use App\Http\Controllers\SocialAuthController;
 use App\Http\Controllers\OrganizationController;
-use App\Http\Controllers\PostController;
 use App\Http\Controllers\SocialAccountController;
 use App\Http\Controllers\SocialNetworkController;
 
@@ -27,6 +28,7 @@ Route::group(['middleware' => ['auth:sanctum','IsAdmin']], function () {
     Route::delete('organizations/{organizations}/remove-user/{user}', [OrganizationController::class, 'removeUser']);
     Route::apiResource('organizations', OrganizationController::class);
     Route::apiResource('social-networks', SocialNetworkController::class);
+    Route::apiResource('admins', AdminController::class);
 
   });  
 


### PR DESCRIPTION
Add AdminRequest to validate admin payloads with Arabic validation messages, including rules for name, email, password, and optional photo. Implement AdminController with index, store, show, update, and destroy actions wired to a UserRepositoryInterface. Store action hashes passwords, handles optional photo upload to media collection, and returns localized error on upload failure. Index returns AdminResource collection filtered by admin type.

Add getAllByType to UserRepository to query users by type with pagination and fix usage from controller. Register AdminController in API routes.

These changes introduce admin-specific endpoints and validation to manage admin users, centralize user-type querying, and support image uploads.