### PR TITLE
feat(plans): add plans API, model migrations, repo binding

### DIFF
--- a/app/Http/Controllers/PlanController.php
+++ b/app/Http/Controllers/PlanController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Http\Resources\PlanResource;
+use App\Http\Requests\Plan\StoreRequest;
+use App\Http\Requests\Plan\UpdateRequest;
+use App\Repositories\Interfaces\PlanRepositoryInterface;
+
+class PlanController extends Controller
+{
+private PlanRepositoryInterface $PlanRepository;
+    
+    public function __construct(PlanRepositoryInterface $PlanRepository,)
+    {$this->PlanRepository = $PlanRepository;}
+
+ 
+    public function index(Request $request)
+    {
+        $plans = $this->PlanRepository->getActive();
+         return PlanResource::collection($plans);
+    }
+    public function show($slug)
+    {
+        $plan = $this->PlanRepository->getBySlug($slug);
+        if ($plan) {
+            return new PlanResource($plan);
+        }
+        return response()->json(['message' => 'Plan not found'], 404);
+    }
+
+    public function store(StoreRequest $request)
+    {
+        $data = $request->validated();
+
+        $plan = $this->PlanRepository->create($data);
+        return new PlanResource($plan);
+    }
+
+    public function update(UpdateRequest $request, $slug)
+    {
+        $data = $request->validated();
+        $data = array_filter($data, fn($value) => $value !== null);
+        $plan = $this->PlanRepository->update($slug, $data);
+        if ($plan) {
+            return new PlanResource($plan);
+        }
+        return response()->json(['message' => 'Plan not found'], 404);
+    }
+
+    public function destroy($slug)
+    {
+        $deleted = $this->PlanRepository->delete($slug);
+        if ($deleted) {
+            return response()->json(['message' => 'Plan deleted successfully']);
+        }
+        return response()->json(['message' => 'Plan not found'], 404);
+    }
+}

--- a/app/Http/Requests/Plan/StoreRequest.php
+++ b/app/Http/Requests/Plan/StoreRequest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Requests\Plan;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'posts_per_month' => 'required|integer',
+            'reels_per_month' => 'required|integer',
+            'stories_per_month' => 'required|integer',
+            'price' => 'required|numeric',
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'name.required' => 'اسم الخطة مطلوب.',
+            'name.string' => 'اسم الخطة يجب أن يكون نص فقط.',
+            'name.max' => 'اسم الخطة لا يجب أن يزيد عن 255 حرف.',
+
+            'posts_per_month.required' => 'عدد البوستات مطلوب.',
+            'posts_per_month.integer' => 'عدد البوستات يجب أن يكون رقم صحيح.',
+
+            'reels_per_month.required' => 'عدد الريلز مطلوب.',
+            'reels_per_month.integer' => 'عدد الريلز يجب أن يكون رقم صحيح.',
+
+            'stories_per_month.required' => 'عدد الاستوري مطلوب.',
+            'stories_per_month.integer' => 'عدد الاستوري يجب أن يكون رقم صحيح.',
+
+            'price.required' => 'سعر الخطة مطلوب.',
+            'price.numeric' => 'سعر الخطة يجب أن يكون رقم.',
+        ];
+    }
+}

--- a/app/Http/Requests/Plan/UpdateRequest.php
+++ b/app/Http/Requests/Plan/UpdateRequest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Requests\Plan;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name'              => 'sometimes|nullable|string|max:255',
+            'posts_per_month'   => 'sometimes|nullable|integer',
+            'reels_per_month'   => 'sometimes|nullable|integer',
+            'stories_per_month' => 'sometimes|nullable|integer',
+            'price'             => 'sometimes|nullable|numeric',
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'name.required' => 'اسم الخطة مطلوب.',
+            'name.string' => 'اسم الخطة يجب أن يكون نص فقط.',
+            'name.max' => 'اسم الخطة لا يجب أن يزيد عن 255 حرف.',
+
+            'posts_per_month.required' => 'عدد البوستات مطلوب.',
+            'posts_per_month.integer' => 'عدد البوستات يجب أن يكون رقم صحيح.',
+
+            'reels_per_month.required' => 'عدد الريلز مطلوب.',
+            'reels_per_month.integer' => 'عدد الريلز يجب أن يكون رقم صحيح.',
+
+            'stories_per_month.required' => 'عدد الاستوري مطلوب.',
+            'stories_per_month.integer' => 'عدد الاستوري يجب أن يكون رقم صحيح.',
+
+            'price.required' => 'سعر الخطة مطلوب.',
+            'price.numeric' => 'سعر الخطة يجب أن يكون رقم.',
+        ];
+    }
+}

--- a/app/Http/Resources/PlanResource.php
+++ b/app/Http/Resources/PlanResource.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PlanResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'slug'  => $this->slug,
+            'name'  => $this->name,
+            'posts_per_month' => $this->posts_per_month,
+            'reels_per_month' => $this->reels_per_month,
+            'stories_per_month' => $this->stories_per_month,
+            'price' => $this->price,
+            'organizations' => OrganizationResource::collection($this->whenLoaded('organizations')),
+        ];
+    }
+}

--- a/app/Models/Plan.php
+++ b/app/Models/Plan.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use Spatie\Sluggable\HasSlug;
+use Laravel\Sanctum\HasApiTokens;
+use Spatie\Sluggable\SlugOptions;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class Plan extends Model
+{
+    use HasApiTokens, HasFactory, HasSlug, SoftDeletes;
+    protected $fillable = [
+        'slug',
+        'name',
+        'posts_per_month',
+        'reels_per_month',
+        'stories_per_month',
+        'price',
+    ];
+
+    public function getSlugOptions(): SlugOptions
+    {
+        return SlugOptions::create()
+            ->generateSlugsFrom('name')
+            ->saveSlugsTo('slug');
+    }
+    
+    public function organizations()
+    {
+        return $this->belongsToMany(Organization::class, 'subscriptions')
+                    ->withPivot(['is_active', 'starts_at', 'ends_at']) 
+                    ->withTimestamps();
+    }
+
+    public function subscriptions()
+    {
+        return $this->hasMany(Subscription::class);
+    }
+}

--- a/app/Models/Subscription.php
+++ b/app/Models/Subscription.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Laravel\Sanctum\HasApiTokens;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class Subscription extends Model
+{
+    use HasApiTokens, HasFactory, SoftDeletes;
+
+    protected $fillable = [
+        'organization_id',
+        'plan_id',
+        'starts_at',
+        'ends_at',
+        'is_active'
+    ];
+
+    public function organization()
+    {
+        return $this->belongsTo(Organization::class);
+    }
+
+    public function plan()
+    {
+        return $this->belongsTo(Plan::class);
+    }
+}

--- a/app/Models/organization.php
+++ b/app/Models/organization.php
@@ -36,5 +36,20 @@ class organization extends Model  implements HasMedia
         return $this->belongsToMany(User::class);
     }
 
-  
+    public function subscriptions()
+    {
+        return $this->hasMany(Subscription::class);
+    }
+
+    public function currentPlan()
+    {
+        return $this->hasOne(Subscription::class)->where('is_active', true);
+    }
+
+    public function plans()
+    {
+        return $this->belongsToMany(Plan::class, 'subscriptions')
+                    ->withPivot(['is_active', 'starts_at', 'ends_at'])
+                    ->withTimestamps();
+    }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Repositories\PlanRepository;
 use App\Repositories\PostRepository;
 use App\Repositories\UserRepository;
 use Illuminate\Support\Facades\Schema;
@@ -9,6 +10,7 @@ use Illuminate\Support\ServiceProvider;
 use App\Repositories\OrganizationRepository;
 use App\Repositories\SocialAccountRepository;
 use App\Repositories\SocialNetworkRepository;
+use App\Repositories\Interfaces\PlanRepositoryInterface;
 use App\Repositories\Interfaces\PostRepositoryInterface;
 use App\Repositories\Interfaces\UserRepositoryInterface;
 use App\Repositories\Interfaces\OrganizationRepositoryInterface;
@@ -22,7 +24,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-
+        $this->app->bind(PlanRepositoryInterface::class, PlanRepository::class);
         $this->app->bind(PostRepositoryInterface::class, PostRepository::class);
         $this->app->bind(SocialAccountRepositoryInterface::class, SocialAccountRepository::class);
         $this->app->bind(SocialNetworkRepositoryInterface::class, SocialNetworkRepository::class);

--- a/app/Repositories/Interfaces/PlanRepositoryInterface.php
+++ b/app/Repositories/Interfaces/PlanRepositoryInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Repositories\Interfaces;
+
+interface PlanRepositoryInterface
+{
+    public function getAll();
+    public function getActive();
+    public function getBySlug($slug);
+    public function create(array $attributes);
+    public function update($slug, array $attributes);
+    public function delete($slug);
+}

--- a/app/Repositories/PlanRepository.php
+++ b/app/Repositories/PlanRepository.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Repositories\Interfaces\PlanRepositoryInterface;
+use App\Models\Plan; // Assumption: You have a Model with the same name
+
+class PlanRepository implements PlanRepositoryInterface
+{
+    public function getAll()
+    {
+        return Plan::all();
+    }
+    public function getActive()
+    {
+        return Plan::all();
+    }
+
+    public function getBySlug($slug)
+    {
+        return Plan::where('slug', $slug)
+            ->with('organizations') 
+            ->first();
+    }
+
+
+    public function create(array $attributes)
+    {
+        return Plan::create($attributes);
+    }
+
+    public function update($slug, array $attributes)
+    {
+        $record = Plan::query()
+            ->where('slug', $slug)
+            ->first();
+        if ($record) {
+            $record->update($attributes);
+            return $record;
+        }
+        return null;
+    }
+
+    public function delete($slug)
+    {
+        $record = Plan::query()
+            ->where('slug', $slug)
+            ->first();
+        if ($record) {
+            return $record->delete();
+        }
+    }
+}

--- a/app/Services/SocialNetworks/FacebookService.php
+++ b/app/Services/SocialNetworks/FacebookService.php
@@ -19,8 +19,8 @@ class FacebookService implements SocialNetworkInterface
 
     public function getAuthUrl(): string
     {
-        $scopes = "public_profile,email,pages_show_list,pages_manage_posts,pages_read_engagement";
-
+        //$scopes = "public_profile,email,pages_show_list,pages_manage_posts,pages_read_engagement";
+        $scopes = "public_profile,email";
         return "https://www.facebook.com/v17.0/dialog/oauth?"
             . http_build_query([
                 'client_id'     => $this->clientId,
@@ -96,13 +96,4 @@ class FacebookService implements SocialNetworkInterface
         return $response->json();
     }
 
-    // public function publishPost(string $accessToken, array $data): array
-    // {
-    //     $response = Http::post("https://graph.facebook.com/me/feed", [
-    //         'message'       => $data['message'] ?? '',
-    //         'access_token'  => $accessToken,
-    //     ]);
-
-    //     return $response->json();
-    // }
 }

--- a/database/migrations/2025_08_26_190030_create_plans_table.php
+++ b/database/migrations/2025_08_26_190030_create_plans_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('plans', function (Blueprint $table) {
+            $table->id();
+            $table->string('slug')->unique(); 
+            $table->string('name'); 
+            $table->integer('posts_per_month')->default(0);
+            $table->integer('reels_per_month')->default(0);
+            $table->integer('stories_per_month')->default(0);
+            $table->decimal('price', 10, 2)->default(0); 
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('plans');
+    }
+};

--- a/database/migrations/2025_08_26_190530_create_subscriptions_table.php
+++ b/database/migrations/2025_08_26_190530_create_subscriptions_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('subscriptions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('organization_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('plan_id')->constrained()->cascadeOnDelete();
+            $table->timestamp('starts_at')->nullable();
+            $table->timestamp('ends_at')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('subscriptions');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -17,6 +17,7 @@ class DatabaseSeeder extends Seeder
             UserSeeder::class,
             SocialNetworkSeeder::class,
             TimeSlotSeeder::class,
+            PlanSeeder::class,
         ]);
     }
 }

--- a/database/seeders/PlanSeeder.php
+++ b/database/seeders/PlanSeeder.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Plan;
+use Illuminate\Database\Seeder;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+
+class PlanSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $plans = [
+            [
+                'name' => 'Basic',
+                'posts_per_month' => 10,
+                'reels_per_month' => 5,
+                'stories_per_month' => 20,
+                'price' => 5,
+            ],
+            [
+                'name' => 'Standard',
+                'posts_per_month' => 30,
+                'reels_per_month' => 15,
+                'stories_per_month' => 60,
+                'price' => 5.2,
+            ],
+            [
+                'name' => 'Premium',
+                'posts_per_month' => 100,
+                'reels_per_month' => 50,
+                'stories_per_month' => 200,
+                'price' => 7.2,
+            ],
+        ];
+
+        foreach ($plans as $plan) {
+            Plan::create($plan);
+        }
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\TimeSlotController;
 use App\Http\Controllers\Auth\AuthController;
 use App\Http\Controllers\SocialAuthController;
 use App\Http\Controllers\OrganizationController;
+use App\Http\Controllers\PlanController;
 use App\Http\Controllers\SocialAccountController;
 use App\Http\Controllers\SocialNetworkController;
 
@@ -29,6 +30,7 @@ Route::group(['middleware' => ['auth:sanctum','IsAdmin']], function () {
     Route::apiResource('organizations', OrganizationController::class);
     Route::apiResource('social-networks', SocialNetworkController::class);
     Route::apiResource('admins', AdminController::class);
+    Route::apiResource('plans', PlanController::class);
 
   });  
 
@@ -52,7 +54,7 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
         Route::get('channels/{account}/{type}', [PostController::class, 'index']);
     });
     Route::apiResource('social-accounts', SocialAccountController::class);
-
+    Route::get('plans', [PlanController::class, 'index']);
 });
 
 


### PR DESCRIPTION
Plan resources and supporting to enable plan
through the API Register PlanController (apiResource + index) and include plans in the public routes list. Create a migration for the plans table with columns slug, name, posts/reels/stories_per_month, price, timestamps and soft deletes. Add UpdateRequest validation for partial plan updates with Arabic validation messages. Bind the PlanRepositoryInterface to PlanRepository in AppServiceProvider, and include PlanSeeder in DatabaseSeeder. These changes introduce the plans domain, validation, persistence and routing to support creating, updating and listing subscription plans.