### PR TITLE
feat(users,plans): add org endpoints and resolve organization

### DIFF
--- a/app/Http/Controllers/PlanController.php
+++ b/app/Http/Controllers/PlanController.php
@@ -4,16 +4,24 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Http\Resources\PlanResource;
+use App\Traits\ResolvesOrganization;
 use App\Http\Requests\Plan\StoreRequest;
 use App\Http\Requests\Plan\UpdateRequest;
 use App\Repositories\Interfaces\PlanRepositoryInterface;
+use App\Repositories\Interfaces\OrganizationRepositoryInterface;
 
 class PlanController extends Controller
 {
-private PlanRepositoryInterface $PlanRepository;
-    
-    public function __construct(PlanRepositoryInterface $PlanRepository,)
-    {$this->PlanRepository = $PlanRepository;}
+    use ResolvesOrganization;
+    private PlanRepositoryInterface $PlanRepository;
+    private OrganizationRepositoryInterface $OrganizationRepository;
+    public function __construct(
+        PlanRepositoryInterface $PlanRepository, OrganizationRepositoryInterface $OrganizationRepository,
+    )
+    {
+        $this->PlanRepository = $PlanRepository;
+        $this->OrganizationRepository = $OrganizationRepository;
+    }
 
  
     public function index(Request $request)
@@ -57,4 +65,46 @@ private PlanRepositoryInterface $PlanRepository;
         }
         return response()->json(['message' => 'Plan not found'], 404);
     }
+
+    public function subscribe(Request $request,  $slug)
+    {
+        $organization = $this->resolveOrganization($request, $this->OrganizationRepository);
+        
+        $plan = $this->PlanRepository->getBySlug($slug);
+           if (!$plan) {
+            return response()->json([
+                'message' => 'plan not found'
+            ], 400);
+        }
+      
+        // $organization = $this->OrganizationRepository->getBySlug($organizationSlug);
+        //    if (!$organization) {
+        //     return response()->json([
+        //         'message' => 'Organization not found'
+        //     ], 400);
+        // }
+
+        // if ($organization->plans()->where('plans.id', $plan->id)->exists()) {
+        //     return response()->json([
+        //         'message' => 'Organization already subscribed to this plan',
+        //     ], 409);
+        // }
+
+        ////
+
+        // // نربط المنظمة بالبلان عن طريق الجدول الوسيط subscriptions
+        // $organization->plans()->attach($plan->id, [
+        //     'status'     => 'active',
+        //     'started_at' => now(),
+        //     'expires_at' => now()->addMonth(), // مثلاً شهر واحد
+        // ]);
+
+        // return response()->json([
+        //     'message' => 'Subscribed successfully',
+        //     'plan'    => $plan->name,
+        //     'org'     => $organization->name,
+        // ]);
+  
+    }
+   
 }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -6,7 +6,9 @@ use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
 use App\Http\Resources\UserResource;
 use App\Http\Requests\User\UserRequest;
+use App\Http\Resources\OrganizationResource;
 use App\Repositories\Interfaces\UserRepositoryInterface;
+use App\Repositories\OrganizationRepository;
 
 class UserController extends Controller
 {
@@ -24,6 +26,16 @@ private UserRepositoryInterface $UserRepository;
 
     }
 
+    public function organizations(Request $request)
+    {
+        $user = $this->UserRepository->getById(auth()->id());
+        $organizations = $user->organizations;
+
+        return response()->json([
+            'message' => 'المنظمات التي ينتمي إليها المستخدم',
+            'data'    => OrganizationResource::collection($organizations)
+        ]);
+    }
     public function update(UserRequest $request)
     {
         $data = $request->validated();

--- a/app/Traits/ResolvesOrganization.php
+++ b/app/Traits/ResolvesOrganization.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Http\Request;
+
+use App\Repositories\Interfaces\OrganizationRepositoryInterface;
+
+trait ResolvesOrganization
+{
+    protected function resolveOrganization(Request $request, OrganizationRepositoryInterface $organizations)
+    {
+        $organizationSlug = $request->header('organization');
+
+        if (!$organizationSlug) {
+            abort(response()->json([
+                'message' => 'Organization slug is required in header (organization)',
+            ], 422));
+        }
+
+        $organization = $organizations->getBySlug($organizationSlug);
+
+        if (!$organization) {
+            abort(response()->json([
+                'message' => 'Organization not found',
+            ], 404));
+        }
+
+        return $organization;
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -37,6 +37,7 @@ Route::group(['middleware' => ['auth:sanctum','IsAdmin']], function () {
 Route::group(['middleware' => ['auth:sanctum']], function () {
     Route::prefix('profile')->group(function () {
         Route::post('logout', [AuthController::class, 'logout']);
+        Route::get('organizations', [UserController::class, 'organizations']);
         Route::get('me', [UserController::class, 'profile']);
         Route::PATCH('update', [UserController::class, 'update']);
         Route::delete('delete', [UserController::class, 'delete']);
@@ -55,6 +56,7 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
     });
     Route::apiResource('social-accounts', SocialAccountController::class);
     Route::get('plans', [PlanController::class, 'index']);
+    Route::get('plans/{slug}/subscribe', [PlanController::class, 'subscribe']);
 });
 
 


### PR DESCRIPTION
- Add UserController::organizations to return authenticated user's organizations using OrganizationResource. This exposes the user's organizations via a new protected profile route.

- Register new API routes:
  - GET profile/organizations -> UserController@organizations
  - GET plans/{slug}/subscribe -> PlanController@subscribe

- Introduce ResolvesOrganization trait to centralize resolving an organization by slug from the request header and to standardize error responses when the header is missing or the organization is not found.

- Extend PlanController:
  - Inject OrganizationRepositoryInterface and use ResolvesOrganization.
  - Add subscribe action that resolves the current organization and looks up the requested plan by slug. Include validation and error responses for missing plan/organization (prepares for subscription logic, commented-out attach logic remains for future completion).

- Add necessary imports and repository fields in controllers and use OrganizationResource for organization serialization.

Reason:
Provide endpoints and shared logic to allow actions that depend on a selected organization (via request header), and scaffold a plan subscription flow that ties plans to organizations. This centralizes organization resolution and prepares for implementing subscription persistence and related checks.